### PR TITLE
Add missing NAME section in lib/SQL/Format/Spec.pod

### DIFF
--- a/lib/SQL/Format/Spec.pod
+++ b/lib/SQL/Format/Spec.pod
@@ -4,6 +4,10 @@
 
 =for stopwords
 
+=head1 NAME
+
+SQL::Format::Spec - The SQL::Format cheat sheet
+
 =head1 sqlf() CHEAT SHEET
 
 This cheat sheet rules are:


### PR DESCRIPTION
This will fix the display of that POD in [the list at MetaCPAN](https://metacpan.org/release/SQL-Format).
