### PR TITLE
following empty WHERE condition

### DIFF
--- a/lib/SQL/Format.pm
+++ b/lib/SQL/Format.pm
@@ -195,6 +195,9 @@ sub _where {
     }
 
     return unless ref $val eq 'HASH';
+
+    return '(1=1)' unless %$val;
+
     my $ret = join ' AND ', map {
         my $org_key  = $_;
         my $no_paren = 0;

--- a/lib/SQL/Format/Spec.pod
+++ b/lib/SQL/Format/Spec.pod
@@ -609,6 +609,12 @@ For example:
   WHERE (1=1)
   []
 
+  # empty condition
+  WHERE %w
+  {}
+  WHERE (1=1)
+  []
+
 =head2 where hash mixed
 
   # mixied scalar

--- a/t/21_format.t
+++ b/t/21_format.t
@@ -17,4 +17,16 @@ $test->(
     },
 );
 
+$test->(
+    desc    => 'following empty where condition',
+    input   => [
+        'SELECT %c FROM %t WHERE %w',
+        [qw/bar baz/], 'foo', {},
+    ],
+    expects => {
+        stmt => 'SELECT `bar`, `baz` FROM `foo` WHERE (1=1)',
+        bind => [],
+    },
+);
+
 done_testing;


### PR DESCRIPTION
The following code makes invalid SQL:
```perl
my ($stmt, @bind) = sqlf 'SELECT id FROM foo WHERE %w', {};
# $stmt => "SELECT id FROM WHERE " is invalid
```

This fix makes valid SQL in the case.